### PR TITLE
add executable flag and shebang on `start_{signer,coordinator}` scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,12 @@ Coordinators act as a mediator between digital signers and wallets.  The coordin
     ```
 2. Start the coordinator
     ```
-    python3 start_coordinator.py
+    ./start_coordinator.py
     ```
 
 ### Running a signer
 
-```
-python3 start_signer.py
-```
+`./start_signer.py`
 
 
 Possible arguments:

--- a/start_coordinator.py
+++ b/start_coordinator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from src.coordinator.coordinator import run
 
 def main():

--- a/start_signer.py
+++ b/start_signer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from src.signer.signer import run_signer
 
 import sys


### PR DESCRIPTION
It's a slightly nicer user experience if the start scripts can be just called directly without having to explicitly specify the interpreter. Btw, congratulations on winning the competition, very nice project! :tada: