### PR TITLE
[signer, readme] cleanup signer + update e2e test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ Possible arguments:
 ### Completing an end-to-end test
 
 1. Start the coordinator
-2. In a separate terminal window, start a signer. Execute the "new wallet" command. When prompted to specify a quorum, enter "2". Take note of the wallet ID that is returned.
-3. In a separate terminal window, start a second signer with the `--wallet_id` flag set to the wallet ID that was returned in the previous step.
-4. Have each signer send keys to the coordinator (`send pk` command)
-5. Have each signer get an address from the coordinator (`address`). Confirm that the addresses are the same. This address corresponds to an aggregate pubkey that combines the keys of each signer.
-6. Outside of Munstr, fund the address.
-7. Have one signer initiate a spend by using the `spend` command.
-8. Execute the `sign` command from each of the signers. After all signers have provided nonces, the coordinator will return the aggregate nonce, and the signers will be prompted to provide a partial signature. The coordinator will then aggregate the signatures and provide a raw hex transaction that is ready for broadcast!
+2. In a separate terminal window, start a signer (Signer1) and use the `--key_seed` option to set a seed for the key, and the `--nonce_seed` option to set the nonce seed (must be an integer). Example: `./start_signer.py --key_seed=key0 --nonce_seed=256`
+3. Signer1: Execute the "new wallet" command. When prompted to specify a quorum, enter "2". Take note of the wallet ID that is returned.
+4. In a separate terminal window, start a second signer (Signer2) with the `--wallet_id` flag set to the wallet ID that was returned in the previous step. Example: `./start_signer.py --key_seed=key1 --nonce_seed=256 --wallet_id=527f0dee-8b2a-45a1-87c6-98e9b6f642f7`
+5. Have each signer send keys to the coordinator (`send pk` command)
+6. Have each signer get an address from the coordinator (`address`). Confirm that the addresses are the same. This address corresponds to an aggregate pubkey that combines the keys of each signer.
+7. Outside of Munstr, fund the address.
+8. Have one signer initiate a spend by using the `spend` command.
+9. Execute the `sign` command from each of the signers. After all signers have provided nonces, the coordinator will return the aggregate nonce, and the signers will be prompted to provide a partial signature. The coordinator will then aggregate the signatures and provide a raw hex transaction that is ready for broadcast!
 
 ## Demo 
 [![Munstr Demo](https://img.youtube.com/vi/9AhzEatrZbg/0.jpg)](https://www.youtube.com/watch?v=9AhzEatrZbg)


### PR DESCRIPTION
Signer: Some code cleanup. Sorry this PR isn't more organized. Still in hackathon mode :smile: 

- New synchronous `wait_for_coordinator` method for commands that expect one response from the coordinator
- convert a bunch of print statements to `logging`
- correct spelling of "coordinator" in some places :)
- use `src.utils.nostr_utils` methods to read nsec and coordinator public key
- new `SignerCommands` enum for all the valid commands a signer can provide

README: Update steps on how to start the signer. Right now the key and nonce seeds are required.

Tested this locally and executed the `new wallet`, `send pk` and `address` commands. Did not test signing, but I also didn't touch much of that code.
