### PR TITLE
remove unneeded `uuid` module from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ bip32
 nostr
 colorama
 python-bitcoinlib
-uuid


### PR DESCRIPTION
The `uuid` module has been part of the Python3 standard library for a long time (at least v3.5, see https://docs.python.org/3.5/library/uuid.html), i.e. there's no need to have it as dependency in the requirements.txt file and download an extra package from pip3.

That everything works fine can be verified by uninstalling the pip3 one:
```
    $ pip3 uninstall uuid
```
and executing the typical test procedure as described in README.md.